### PR TITLE
Corrección de los datos del tooltip en "Grafica de barras vertical con tooltip"

### DIFF
--- a/src/js/bar-vertical-tooltip.js
+++ b/src/js/bar-vertical-tooltip.js
@@ -100,7 +100,7 @@ const barVerticalTooltip = () => {
                 tooltip.transition()
                 .duration(300)
                 .style("opacity", 1);
-                tooltip.html('<div class="tooltip-lluvia-mes-container"><p class="tooltip-lluvia-mes">Lluvia acumulada en ' + d.dias + '<span class="tooltip-lluvia-mes-total">: ' + d.fecha + 'mm</span><p/><p class="tooltip-lluvia-mes">Lluvia acumulada en ' + d.precipitacion_anual + '<span class="tooltip-lluvia-mes-total">: ' + d.fecha + 'mm</span><p/></div>')
+                tooltip.html('<div class="tooltip-lluvia-mes-container"><p class="tooltip-lluvia-mes">Lluvia acumulada en ' + d.fecha + '<span class="tooltip-lluvia-mes-total">: ' + d.dias + 'mm</span><p/><p class="tooltip-lluvia-mes">Lluvia acumulada en ' + d.fecha + '<span class="tooltip-lluvia-mes-total">: ' + d.precipitacion_anual + 'mm</span><p/></div>')
             })
             .on("mouseout", d => {
                 tooltip.style("opacity", 0)


### PR DESCRIPTION
Están intercambiados los datos y los años en el tooltip.
Dice, por ejemplo: "Lluvia acumulada en 48: **1963mm**".
Modifiqué el js en /src, no hice el _build_.